### PR TITLE
List of available atmospheric properties : add 2 missing parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,8 @@ Atmospheric properties are computed from an "Atmosphere object" which takes the 
 * Collision frequency (``collision_frequency``)
 * Density (``density``)
 * Dynamic viscosity (``dynamic_viscosity``)
+* Geometric height above MSL (``h``)
+* Geopotential height (``h``)
 * Gravitational acceleration (``grav_accel``)
 * Kinematic viscosity (``kinematic_viscosity``)
 * Layer names (``layer_name``) [string array]

--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Atmospheric properties are computed from an "Atmosphere object" which takes the 
 * Density (``density``)
 * Dynamic viscosity (``dynamic_viscosity``)
 * Geometric height above MSL (``h``)
-* Geopotential height (``h``)
+* Geopotential height (``H``)
 * Gravitational acceleration (``grav_accel``)
 * Kinematic viscosity (``kinematic_viscosity``)
 * Layer names (``layer_name``) [string array]

--- a/docs/source/user_guide/detailed_user_guide.rst
+++ b/docs/source/user_guide/detailed_user_guide.rst
@@ -65,11 +65,11 @@ Computing atmospheric properties
 
 **List of available atmospheric properties**
 
-* Geometric height (``h``)
-* Geopotential height (``H``)
 * Collision frequency (``collision_frequency``)
 * Density (``density``)
 * Dynamic viscosity (``dynamic_viscosity``)
+* Geometric height above MSL (``h``)
+* Geopotential height (``H``)
 * Gravitational acceleration (``grav_accel``)
 * Kinematic viscosity (``kinematic_viscosity``)
 * Layer names (``layer_name``) [string array]

--- a/docs/source/user_guide/detailed_user_guide.rst
+++ b/docs/source/user_guide/detailed_user_guide.rst
@@ -65,6 +65,8 @@ Computing atmospheric properties
 
 **List of available atmospheric properties**
 
+* Geometric height (``h``)
+* Geopotential height (``H``)
 * Collision frequency (``collision_frequency``)
 * Density (``density``)
 * Dynamic viscosity (``dynamic_viscosity``)


### PR DESCRIPTION
List of available atmospheric properties : add 2 missing parameters
Update detailed_user_guide.rst
Due to the new feature ".from_pressure", it can be necessary to ask for the geometric altitude ".h".