### PR TITLE
Read the version using exec during build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,17 @@
 
 import setuptools
 import os
+from pathlib import Path
 
-from src.ambiance.__version__ import __version__
+here = Path(__file__).parent.resolve()
+# See also: https://packaging.python.org/guides/single-sourcing-package-version/
+version = {}
+exec(here.joinpath("src", "ambiance", "__version__.py").read_text(), version)
 
 # See also: https://github.com/kennethreitz/setup.py/blob/master/setup.py
 
 NAME = 'ambiance'
-VERSION = __version__
+VERSION = version["__version__"]
 AUTHOR = 'Aaron Dettmann'
 EMAIL = 'dettmann@kth.se'
 DESCRIPTION = 'A full implementation of the ICAO standard atmosphere 1993'
@@ -23,19 +27,13 @@ README = 'README.rst'
 PACKAGE_DIR = 'src/'
 LICENSE = 'Apache License 2.0'
 
-
-here = os.path.abspath(os.path.dirname(__file__))
-
-with open(os.path.join(here, README), "r") as fp:
-    long_description = fp.read()
-
 setuptools.setup(
     name=NAME,
     version=VERSION,
     author=AUTHOR,
     author_email=EMAIL,
     description=DESCRIPTION,
-    long_description=long_description,
+    long_description=here.joinpath(README).read_text(),
     url=URL,
     include_package_data=True,
     package_dir={'': PACKAGE_DIR},
@@ -57,4 +55,9 @@ setuptools.setup(
         "Topic :: Scientific/Engineering :: Physics",
         "Topic :: Scientific/Engineering :: Atmospheric Science",
     ],
+    project_urls={
+        'Documentation': 'https://ambiance.readthedocs.io/',
+        'Source': URL,
+        'Tracker': URL + 'issues',
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ REQUIRED = [
     'scipy',
 ]
 README = 'README.rst'
-PACKAGE_DIR = 'src/'
+PACKAGE_DIR = 'src'
 LICENSE = 'Apache License 2.0'
 
 setuptools.setup(


### PR DESCRIPTION
Hi! Thank you for providing this package, I've been using it in teaching my propulsion class. I really like the interface, it's very easy. To help my students use the package, I've been working on a [conda package](https://github.com/conda-forge/staged-recipes/pull/14108) on the `conda-forge` channel. I'd be happy to add you as a maintainer over there, if you're interested. If not, I'm totally fine keeping the package up-to-date on conda.

In any case, one of the things I noticed was that NumPy and SciPy need to be installed in the build environment to be able to import the package, to read the version. Since this isn't strictly required, I thought it might be better to `exec()` the `__version__.py` file in `setup.py`, and avoid the imports. This method is recommended by the PyPA over here: https://packaging.python.org/guides/single-sourcing-package-version/

I also added some more URLs for the project which will update the PyPI page, with the documentation and link to the issue tracker here.

One other small thing is that building the package from source on Windows results in an error due to the trailing slash in the `package_dir` option. This doesn't seem to be required on any platform, so I removed it.

If this is not of interest, please feel free to close this pull request. Thanks again for the package!